### PR TITLE
feat: mock callSid generator for blocking twilio call

### DIFF
--- a/Atempo/src/main/java/juton113/Atempo/service/AdmissionService.java
+++ b/Atempo/src/main/java/juton113/Atempo/service/AdmissionService.java
@@ -51,7 +51,8 @@ public class AdmissionService {
         // request twilio call
         for(CreateHospitalResponseDto createHospitalResponseDto : hospitalList) {
             String hospitalNumber = createHospitalResponseDto.getPhoneNumber();
-            String callId = twilioService.createCall(hospitalNumber, arsMessage);
+//            String callId = twilioService.createCall(hospitalNumber, arsMessage);
+            String callId = twilioService.createMockCall(hospitalNumber, arsMessage);
 
             CreateHospitalDto createHospitalDto = CreateHospitalDto.builder()
                     .admission(admission)

--- a/Atempo/src/main/java/juton113/Atempo/service/TwilioService.java
+++ b/Atempo/src/main/java/juton113/Atempo/service/TwilioService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 
 @Service
 public class TwilioService {
@@ -55,6 +56,14 @@ public class TwilioService {
                 .build();
 
         return response.toXml();
+    }
+
+    public String createMockCall(String toPhoneNumber, String arsMessage) {
+        return  generateMockCallSid();
+    }
+
+    private String generateMockCallSid() {
+        return "CA" + UUID.randomUUID().toString().replace("-", "").substring(0, 32);
     }
 
 }


### PR DESCRIPTION
1. callSid 생성기 추가.
2. 실제 twilio call api 호출을 막고 대신 callSid 생성기에서 생성된 sid로 call id 대체